### PR TITLE
feat: makes adding an issue to a project board optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # First responder
 
-This action searches for team pings in issues and pull requests in an organization. The issues and pull requests are added to an organization project board. You can add a comment to the issue or pull request letting people know that your team will first respond soon.
+This action searches for team pings in issues and pull requests in an organization. The issues and pull requests are added to an organization project board, if desired. You can add a comment to the issue or pull request letting people know that your team will first respond soon.
 
 # Input parameters
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -506,7 +506,7 @@ async function run () {
   const since = core.getInput('since') !== ''
     ? core.getInput('since') : '2020-01-01'
   const projectBoard = core.getInput('project-board') || null
-  const columnId = parseInt(core.getInput('project-column'), 10)  || null
+  const columnId = parseInt(core.getInput('project-column'), 10) || null
   const ignoreTeam = core.getInput('ignore-team')
   const includeReviewRequests = core.getInput('include-review-requests')
   const body = core.getInput('comment-body')
@@ -548,7 +548,7 @@ async function run () {
   // Get unique issues from the 2 results and combine them into single array
   let issues = {}
   if (includeReviewRequests === 'true') {
-    teamMentions.data.items.concat(includeReviewRequests === 'true' ? teamReviewRequests.data.items : []).forEach( i => {
+    teamMentions.data.items.concat(includeReviewRequests === 'true' ? teamReviewRequests.data.items : []).forEach(i => {
       // easy way to ensure uniq by key => val all the id
       issues[i.id] = i
     })
@@ -610,7 +610,7 @@ async function getTeamReviewRequests (octokit, org, team, authors, commenters, s
 }
 
 async function buildExceptions (authors, commenters, since = '2019-01-01', projectBoard, ignoreRepos, ignoreLabels) {
-  let query = ""
+  let query = ''
   for (const author of authors) {
     query = query.concat(`+-author%3A${author}`)
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -505,8 +505,8 @@ async function run () {
   const fullTeamName = `${org}/${team}`
   const since = core.getInput('since') !== ''
     ? core.getInput('since') : '2020-01-01'
-  const projectBoard = core.getInput('project-board')
-  const columnId = parseInt(core.getInput('project-column'), 10)
+  const projectBoard = core.getInput('project-board') || null
+  const columnId = parseInt(core.getInput('project-column'), 10)  || null
   const ignoreTeam = core.getInput('ignore-team')
   const includeReviewRequests = core.getInput('include-review-requests')
   const body = core.getInput('comment-body')
@@ -520,7 +520,7 @@ async function run () {
     ? core.getInput('ignore-commenters').split(',').map(x => x.trim()) : []
   const octokit = new GitHub(token)
 
-  const projectInfo = await getProjectMetaData(projectBoard, org)
+  const projectInfo = projectBoard ? await getProjectMetaData(projectBoard, org) : null
 
   // Create a list of users to ignore in the search query
   let teamMembers = []
@@ -567,7 +567,10 @@ async function run () {
   for (const issue of issues) {
     let [, , , owner, repo, contentType, number] = issue.html_url.split('/')
     contentType = contentType === 'issues' ? 'Issue' : 'PullRequest'
-    await addProjectCard(octokit, owner, repo, number, contentType, columnId)
+
+    if (projectBoard && columnId) {
+      await addProjectCard(octokit, owner, repo, number, contentType, columnId)
+    }
 
     if (body !== '') {
       const comment = await octokit.issues.createComment({
@@ -629,9 +632,11 @@ async function buildExceptions (authors, commenters, since = '2019-01-01', proje
   })
 
   // Ignore issues already on the project board
-  const ref = projectBoard.repo !== undefined
-    ? `${projectBoard.owner}%2F${projectBoard.repo}` : projectBoard.owner
-  query = query.concat(`+-project%3A${ref}%2F${projectBoard.number}`)
+  if (projectBoard) {
+    const ref = projectBoard.repo !== undefined
+      ? `${projectBoard.owner}%2F${projectBoard.repo}` : projectBoard.owner
+    query = query.concat(`+-project%3A${ref}%2F${projectBoard.number}`)
+  }
 
   return query
 }
@@ -2210,7 +2215,7 @@ module.exports = require("https");
 /***/ 215:
 /***/ (function(module) {
 
-module.exports = {"name":"@octokit/rest","version":"16.43.1","publishConfig":{"access":"public"},"description":"GitHub REST API client for Node.js","keywords":["octokit","github","rest","api-client"],"author":"Gregor Martynus (https://github.com/gr2m)","contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"repository":"https://github.com/octokit/rest.js","dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^3.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^5.1.2","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"types":"index.d.ts","scripts":{"coverage":"nyc report --reporter=html && open coverage/index.html","lint":"prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","lint:fix":"prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","pretest":"npm run -s lint","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","build":"npm-run-all build:*","build:ts":"npm run -s update-endpoints:typescript","prebuild:browser":"mkdirp dist/","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","prevalidate:ts":"npm run -s build:ts","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","start-fixtures-server":"octokit-fixtures-server"},"license":"MIT","files":["index.js","index.d.ts","lib","plugins"],"nyc":{"ignore":["test"]},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}]};
+module.exports = {"_args":[["@octokit/rest@16.43.1","/Users/lindseywild/Documents/github/first-responder"]],"_from":"@octokit/rest@16.43.1","_id":"@octokit/rest@16.43.1","_inBundle":false,"_integrity":"sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==","_location":"/@octokit/rest","_phantomChildren":{"@types/node":"14.0.5","deprecation":"2.3.1","once":"1.4.0","os-name":"3.1.0"},"_requested":{"type":"version","registry":true,"raw":"@octokit/rest@16.43.1","name":"@octokit/rest","escapedName":"@octokit%2frest","scope":"@octokit","rawSpec":"16.43.1","saveSpec":null,"fetchSpec":"16.43.1"},"_requiredBy":["/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz","_spec":"16.43.1","_where":"/Users/lindseywild/Documents/github/first-responder","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/rest.js/issues"},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}],"contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"description":"GitHub REST API client for Node.js","devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^3.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^5.1.2","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"files":["index.js","index.d.ts","lib","plugins"],"homepage":"https://github.com/octokit/rest.js#readme","keywords":["octokit","github","rest","api-client"],"license":"MIT","name":"@octokit/rest","nyc":{"ignore":["test"]},"publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/rest.js.git"},"scripts":{"build":"npm-run-all build:*","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","build:ts":"npm run -s update-endpoints:typescript","coverage":"nyc report --reporter=html && open coverage/index.html","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","lint":"prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","lint:fix":"prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","prebuild:browser":"mkdirp dist/","pretest":"npm run -s lint","prevalidate:ts":"npm run -s build:ts","start-fixtures-server":"octokit-fixtures-server","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts"},"types":"index.d.ts","version":"16.43.1"};
 
 /***/ }),
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ async function run () {
   const since = core.getInput('since') !== ''
     ? core.getInput('since') : '2020-01-01'
   const projectBoard = core.getInput('project-board') || null
-  const columnId = parseInt(core.getInput('project-column'), 10)  || null
+  const columnId = parseInt(core.getInput('project-column'), 10) || null
   const ignoreTeam = core.getInput('ignore-team')
   const includeReviewRequests = core.getInput('include-review-requests')
   const body = core.getInput('comment-body')
@@ -51,7 +51,7 @@ async function run () {
   // Get unique issues from the 2 results and combine them into single array
   let issues = {}
   if (includeReviewRequests === 'true') {
-    teamMentions.data.items.concat(includeReviewRequests === 'true' ? teamReviewRequests.data.items : []).forEach( i => {
+    teamMentions.data.items.concat(includeReviewRequests === 'true' ? teamReviewRequests.data.items : []).forEach(i => {
       // easy way to ensure uniq by key => val all the id
       issues[i.id] = i
     })
@@ -113,7 +113,7 @@ async function getTeamReviewRequests (octokit, org, team, authors, commenters, s
 }
 
 async function buildExceptions (authors, commenters, since = '2019-01-01', projectBoard, ignoreRepos, ignoreLabels) {
-  let query = ""
+  let query = ''
   for (const author of authors) {
     query = query.concat(`+-author%3A${author}`)
   }


### PR DESCRIPTION
On the Accessibility team, we don't use an FR Triage board. We'd like to copy the functionality of adding a comment when our team is tagged, though, for more information on how to contact us.

This PR makes adding a project ID & column ID optional. If this feature is not desired, let me know and I can do this in a separate repo!